### PR TITLE
Add Australia to organisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Awesome Amateur Radio Resources and Links.
 
 # organizations
 
+- Australia 🇦🇺
+  - [WIA](https://www.wia.org.au)
 - Canada 🇨🇦
   - [RAC](https://www.rac.ca/) 
 - Germany 🇩🇪


### PR DESCRIPTION
More to come but this is a simple start. Add the Wireless Institute of Australia.